### PR TITLE
fix warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .~lock*
 .DS_Store
+readODS.Rproj

--- a/R/readODS.R
+++ b/R/readODS.R
@@ -247,7 +247,7 @@ read_ods <- function(path = NULL, sheet = 1, col_names = TRUE, col_types = NULL,
     parsed_df <- to_data_frame(cell_values = cell_values, header = col_names, na = na)
     if (is.null(col_types)) {
         raw_sheet <- readr::type_convert(df = parsed_df)
-    } else if (is.na(col_types)) {
+    } else if (any(is.na(col_types))) {
         raw_sheet <- parsed_df
     } else {
         raw_sheet <- readr::type_convert(df = parsed_df, col_types = col_types)


### PR DESCRIPTION
using `col_types` with multiple column type specification throws:
```
Warning message:
In if (is.na(col_types)) { :
    the condition has length > 1 and only the first element will be used
``` 
and `read_ods` does not use the `col_types` specification