### PR TITLE
Fixes for readr-1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,3 +18,5 @@ Suggests:
     datasets
 License: GPL-3
 RoxygenNote: 5.0.1
+Remotes:
+  tidyverse/readr

--- a/tests/testthat/test_col_types.R
+++ b/tests/testthat/test_col_types.R
@@ -2,7 +2,7 @@ test_that("col_types ODS", {
     x <- read_ods('../testdata/col_types.ods', col_types = NA)
     expect_equal(class(x[,2]), "character")
     x <- read_ods('../testdata/col_types.ods')
-    expect_equal(class(x[,2]), "integer")
+    expect_equal(class(x[,2]), "numeric")
 })
 
 ### test for issue #41


### PR DESCRIPTION
readr 1.2.0 readr functions no longer guess columns are of type integer,
instead these columns are guessed as numeric.

This breaking change caused an error in your readODS package, fixed by
these changes.

Sorry for the breakage!