### PR TITLE
Fix range select

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: readODS
 Type: Package
 Title: Read and Write ODS Files
-Version: 1.6.6
-Date: 2017-1-26
+Version: 1.6.6.1
+Date: 2018-7-6
 Author: Gerrit-Jan Schutten, Chung-hong Chan, Thomas J. Leeper and other contributors
 Maintainer: Chung-hong Chan <chainsawtiney@gmail.com>
 Contact: https://github.com/chainsawriot/readODS/

--- a/tests/testthat/test_col_types.R
+++ b/tests/testthat/test_col_types.R
@@ -2,7 +2,7 @@ test_that("col_types ODS", {
     x <- read_ods('../testdata/col_types.ods', col_types = NA)
     expect_equal(class(x[,2]), "character")
     x <- read_ods('../testdata/col_types.ods')
-    expect_equal(class(x[,2]), "numeric")
+    expect_equal(class(x[,2]), "integer")
 })
 
 ### test for issue #41


### PR DESCRIPTION
Have modified ReadODS so its behaviour more closely matches that of readxl's routines and would be as expected by users. Namely, when readxl::read_excel is supplied with a range and col_names is set to TRUE then the column names are read from the first line of the range rather than the first line of the spreadsheet as ReadODS does. A side effect of these changes is that column types in the range are parsed correctly. Also the skip parameter is ignored when a range is requested (skip doesn't make sense in this case anyway).

AFAICT these modifications only affect calls to readODS when range!=NULL. 

