### PR TITLE
Prevent processing of comments

### DIFF
--- a/R/readODS.R
+++ b/R/readODS.R
@@ -87,7 +87,7 @@ check_cell_with_textp <- function(cell, ods_ns) {
 }
 
 parse_single_cell <- function(cell, ods_ns, formula_as_formula = FALSE, use_office_value = TRUE) {
-    cell_value <- paste0(xml_text(xml_find_all(cell, ".//text:p", ods_ns)), collapse = "\n") ## handle multiline values, #23
+    cell_value <- paste0(xml_text(xml_find_all(cell, "./text:p", ods_ns)), collapse = "\n") ## handle multiline values, #23
     if (xml_has_attr(cell, "office:value-type", ods_ns) &&
         xml_attr(cell, "office:value-type", ods_ns) %in% c("float", "currency", "percentage")) {
       cell_value <- xml_attr(cell, "office:value", ods_ns)


### PR DESCRIPTION
This change prevents cell comment text being read as cell data. See #52.