### PR TITLE
Avoid apparent Excel bug with string headers

### DIFF
--- a/R/writeODS.R
+++ b/R/writeODS.R
@@ -23,8 +23,9 @@
             
             # add value to row
             thiscell <- xml2::xml_add_child(thisrow, "table:table-cell")
-            xml2::xml_attr(thiscell, "office:value-type") <- if (i == 0 || j == 0) "string" else types[j]
-            xml2::xml_attr(thiscell, "office:value") <- value
+            is_string <- i == 0 || j == 0
+            xml2::xml_attr(thiscell, "office:value-type") <- if (is_string) "string" else types[j]
+            if (!is_string) xml2::xml_attr(thiscell, "office:value") <- value
             xml2::xml_attr(thiscell, "table:style-name") <- "ce1"
             thistext <- xml2::xml_add_child(thiscell, "text:p")
             xml2::xml_text(thistext) <- value


### PR DESCRIPTION
This changes `readODS::writeODS()` to not write the attribute `office:value` when the attribute `office:value-type="string"`.

When Excel reads a certain file created by `readODS::writeODS()`, it shuffles one header to the left, and replaces the ones in-between with zeroes.  This only happens for a particular set of headers. The problem doesn't exist if you open with Google Sheets, or read the ODS back into R. @matt-dray discovered the problem, and created a [gist](https://gist.github.com/matt-dray/9af9dc11e732922211bb19bd879a7e42) to illustrate it.

I created a similar but correct file with Excel, and compared it with the one written by `readODS::writeODS()`.  The cause of the bug appeared to be the presence of the attribute `office:value` in a cell that has a string value.  If the attribute doesn't exist, then Excel reads the file correctly.  LibreOffice also doesn't create the attribute.

For posterity, the gist is pasted below.

```r
# Create dataframe with specifically-named headers
df <- data.frame(D02 = 1, D03 = 2, E01 = 3, E03 = 4, E05 = 5, E06_A = 6)
df
#   D02 D03 E01 E03 E05 E06_A
# 1   1   2   3   4   5     6

# Write out with {readODS}
path <- "~/Desktop/test.ods"  # macOS desktop
readODS::write_ods(df, path)

# Read the ODS back in, no problem
readODS::read_ods(path)
#   D02 D03 E01 E03 E05 E06_A
# 1   1   2   3   4   5     6

# But the headers are wrong when you open in Excel:
# D02 E05   0   0   0 E06_A
#   1   2   3   4   5     6

# Appears to be Excel specific - no problem with Google Sheets
```