### PR TITLE
Fix for TRUE / FALSE in #70

### DIFF
--- a/R/readODS.R
+++ b/R/readODS.R
@@ -223,17 +223,17 @@
 #' @aliases read_ods read.ods
 #' @param path path to the ods file.
 #' @param sheet sheet to read. Either a string (the sheet name), or an integer sheet number. The default is 1.
-#' @param col_names logical, indicating whether the file contains the names of the variables as its first line.
+#' @param col_names logical, indicating whether the file contains the names of the variables as its first line. Default is TRUE.
 #' @param col_types Either NULL to guess from the spreadsheet or refer to readr::type_convert to specify cols specification. NA will return a data frame with all columns being "characters".
 #' @param na Character vector of strings to use for missing values. By default read_ods converts blank cells to missing data.
 #' @param skip the number of lines of the data file to skip before beginning to read data.
-#' @param formula_as_formula logical, a switch to display formulas as formulas "SUM(A1:A3)" or as the resulting value "3"... or "8"..
+#' @param formula_as_formula logical, a switch to display formulas as formulas "SUM(A1:A3)" or as the resulting value "3"... or "8".. . Default is FALSE.
 #' @param range selection of rectangle using Excel-like cell range, such as \code{range = "D12:F15"} or \code{range = "R1C12:R6C15"}. Cell range processing is handled by the \code{\link[=cellranger]{cellranger}} package.
 #' @param file for read.ods only, path to the ods file.
 #' @param formulaAsFormula for read.ods only, a switch to display formulas as formulas "SUM(A1:A3)" or as the resulting value "3"... or "8"..
-#' @param row_names logical, indicating whether the file contains the names of the rows as its first column
-#' @param strings_as_factors logical, if character columns to be converted to factors.
-#' @param verbose logical, if messages should be displayed.
+#' @param row_names logical, indicating whether the file contains the names of the rows as its first column. Default is FALSE.
+#' @param strings_as_factors logical, if character columns to be converted to factors. Default is FALSE.
+#' @param verbose logical, if messages should be displayed. Default is FALSE.
 #' @return A data frame (\code{data.frame}) containing a representation of data in the ods file.
 #' @note Currently, ods files that linked to external data source cannot be read. Merged cells cannot be parsed correctly.
 #' @author Chung-hong Chan <chainsawtiney@@gmail.com>, Gerrit-Jan Schutten <phonixor@@gmail.com>

--- a/R/readODS.R
+++ b/R/readODS.R
@@ -223,15 +223,15 @@
 #' @aliases read_ods read.ods
 #' @param path path to the ods file.
 #' @param sheet sheet to read. Either a string (the sheet name), or an integer sheet number. The default is 1.
-#' @param col_names indicating whether the file contains the names of the variables as its first line.
+#' @param col_names logical, indicating whether the file contains the names of the variables as its first line.
 #' @param col_types Either NULL to guess from the spreadsheet or refer to readr::type_convert to specify cols specification. NA will return a data frame with all columns being "characters".
 #' @param na Character vector of strings to use for missing values. By default read_ods converts blank cells to missing data.
 #' @param skip the number of lines of the data file to skip before beginning to read data.
-#' @param formula_as_formula a switch to display formulas as formulas "SUM(A1:A3)" or as the resulting value "3"... or "8"..
+#' @param formula_as_formula logical, a switch to display formulas as formulas "SUM(A1:A3)" or as the resulting value "3"... or "8"..
 #' @param range selection of rectangle using Excel-like cell range, such as \code{range = "D12:F15"} or \code{range = "R1C12:R6C15"}. Cell range processing is handled by the \code{\link[=cellranger]{cellranger}} package.
 #' @param file for read.ods only, path to the ods file.
 #' @param formulaAsFormula for read.ods only, a switch to display formulas as formulas "SUM(A1:A3)" or as the resulting value "3"... or "8"..
-#' @param row_names indicating whether the file contains the names of the rows as its first column
+#' @param row_names logical, indicating whether the file contains the names of the rows as its first column
 #' @param strings_as_factors logical, if character columns to be converted to factors.
 #' @param verbose logical, if messages should be displayed.
 #' @return A data frame (\code{data.frame}) containing a representation of data in the ods file.

--- a/R/writeODS.R
+++ b/R/writeODS.R
@@ -77,10 +77,10 @@
 #' @param x a data.frame
 #' @param path Path to the ods file to write
 #' @param sheet Name of the sheet
-#' @param row_names logical, TRUE indicates that row names of x are to be included in the sheet
-#' @param col_names logical, TRUE indicates that column names of x are to be included in the sheet
 #' @param append logical, TRUE indicates that x should be appended to the existing file (path) as a new sheet. If a sheet with the same sheet_name exists, an exception is thrown. See update.
 #' @param update logical, TRUE indicates that the sheet with sheet_name in the existing file (path) should be updated with the content of x. If a sheet with sheet_name does not exist, an exception is thrown.
+#' @param row_names logical, TRUE indicates that row names of x are to be included in the sheet
+#' @param col_names logical, TRUE indicates that column names of x are to be included in the sheet
 #' @param verbose logical, if messages should be displayed
 #' @param overwrite logical, deprecated.
 #' @return the value of \code{path} invisibly.

--- a/R/writeODS.R
+++ b/R/writeODS.R
@@ -77,11 +77,11 @@
 #' @param x a data.frame
 #' @param path Path to the ods file to write
 #' @param sheet Name of the sheet
-#' @param append logical, TRUE indicates that x should be appended to the existing file (path) as a new sheet. If a sheet with the same sheet_name exists, an exception is thrown. See update.
-#' @param update logical, TRUE indicates that the sheet with sheet_name in the existing file (path) should be updated with the content of x. If a sheet with sheet_name does not exist, an exception is thrown.
-#' @param row_names logical, TRUE indicates that row names of x are to be included in the sheet
-#' @param col_names logical, TRUE indicates that column names of x are to be included in the sheet
-#' @param verbose logical, if messages should be displayed
+#' @param append logical, TRUE indicates that x should be appended to the existing file (path) as a new sheet. If a sheet with the same sheet_name exists, an exception is thrown. See update. Default is FALSE.
+#' @param update logical, TRUE indicates that the sheet with sheet_name in the existing file (path) should be updated with the content of x. If a sheet with sheet_name does not exist, an exception is thrown. Default is FALSE.
+#' @param row_names logical, TRUE indicates that row names of x are to be included in the sheet. Default is FALSE.
+#' @param col_names logical, TRUE indicates that column names of x are to be included in the sheet. Default is FALSE.
+#' @param verbose logical, if messages should be displayed. Default is FALSE.
 #' @param overwrite logical, deprecated.
 #' @return the value of \code{path} invisibly.
 #' @author Thomas J. Leeper <thosjleeper@@gmail.com>, John Foster <john.x.foster@@nab.com.au>, Chung-hong Chan <chainsawtiney@@gmail.com>


### PR DESCRIPTION
In this PR the issue raised by rOpenSci reviewer (https://github.com/ropensci/software-review/issues/386#issuecomment-664806326) regarding the following comment was addressed and resolve the "TRUE / FALSE" point in issue #70 :

> For the parameters in `write_ods()` that take a `TRUE/FALSE` value, I'd like to see the default value to be explicitly stated here in the documentation.

Additionally, the following documentation fixes has been done:
- Added "logical" to all binary arguments to have more uniform documentation style
- Order or of arguments in documentation now match the function