### PR TITLE
Repeat rows bug, fixes #81, updates #77

### DIFF
--- a/R/readODS.R
+++ b/R/readODS.R
@@ -92,6 +92,9 @@
     for (x in p_content) {
         if (xml2::xml_name(x, ods_ns) == "text:s") {
             rep_space <- as.numeric(xml2::xml_attr(x, "text:c", ns = ods_ns))
+            if (is.na(rep_space)) {
+                rep_space <- 0
+            }
             output <- paste0(output, paste0(rep(" ", rep_space), collapse = ""))
         } else {
             output <- paste0(output, xml2::xml_text(x))

--- a/R/readODS.R
+++ b/R/readODS.R
@@ -126,13 +126,20 @@
     }
     current_row <- 0
     for (row in rows) {
-        current_row <- current_row + 1
+        
         if (xml2::xml_has_attr(row, "table:number-rows-repeated", ods_ns)) {
-            ## empty row, just bump the current_row
-            current_row <- current_row + as.numeric(xml2::xml_attr(row, "table:number-rows-repeated", ods_ns)) - 1
+            ## number of repeats
+            row_repeats <- as.numeric(xml2::xml_attr(row, "table:number-rows-repeated", ods_ns))
         } else {
-            ##parse the value in each column
+            ## if no repeat
+            row_repeats <- 1
+        }
+        
+        for (rep_row in seq_len(row_repeats)) {
+            current_row <- current_row + 1
+            
             current_col <- 0
+            
             for (cell in xml2::xml_find_all(row, ".//table:table-cell", ods_ns)) {
                 bump_cell <- .check_cell_repeat(cell, ods_ns)
                 cell_with_textp <- .check_cell_with_textp(cell, ods_ns)
@@ -153,6 +160,7 @@
                 }
             }
         }
+        
     }
     return(cell_values)
 }


### PR DESCRIPTION
As outlined in issue #81 I discovered a bug where by repeated rows are being treated as empty rather than repetitions.

Fix does the following:

- move check for repeated row to own block, create a row repetition variable (`row_repeats`) which is set to 1 if no repetition (i.e. row appears only once)
- for loop along length of `row_repeats` to insert the necessary number of rows

Also discovered while testing the solution that PR #77 (fixing #74) did not properly account for NAs, added three lines to trap and fix this.

I've tested the fix with the file discussed in #81, and can confirm that it produces the expected result.